### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/addNote.js
+++ b/addNote.js
@@ -1,0 +1,15 @@
+!function(){
+    chrome.storage.sync.get({
+        savedShaarliInstance: "https://example.com/"
+    }, function (items) {
+        const shaarliInstance = items.savedShaarliInstance;
+        const popup = window.open(
+            shaarliInstance +
+            "?post=" +
+            "&description=" +
+            encodeURIComponent(document.getSelection()),
+            "_blank",
+            "menubar=no,height=800,width=600,toolbar=no,scrollbars=yes,status=no,dialog=1"
+        );
+    });
+}();

--- a/addUrl.js
+++ b/addUrl.js
@@ -1,0 +1,21 @@
+!function(){
+    chrome.storage.sync.get({
+        savedShaarliInstance: "https://example.com/"
+    }, function (items) {
+        const shaarliInstance = items.savedShaarliInstance;
+        const o = location.href;
+        const e = document.title || o;
+        const popup = window.open(
+            shaarliInstance +
+            "?post=" +
+            encodeURIComponent(o) +
+            "&title=" +
+            encodeURIComponent(e) +
+            "&description=" +
+            encodeURIComponent(document.getSelection()) +
+            "&source=bookmarklet",
+            "_blank",
+            "menubar=no,height=800,width=600,toolbar=no,scrollbars=yes,status=no,dialog=1"
+        );
+    });
+}();

--- a/background.js
+++ b/background.js
@@ -1,52 +1,80 @@
 const defaultShaarliInstance = "https://example.com/";
 
-function addUrl() {
-  chrome.storage.sync.get({
-    savedShaarliInstance: defaultShaarliInstance
-  }, function (items) {
-    let shaarliInstance = items.savedShaarliInstance;
-    let myCode = "!function(){var o=location.href,e=document.title||o;const popup=window.open('" +
-      shaarliInstance +
-      "?post='+encodeURIComponent(o)+'&title='+encodeURIComponent(e)+'&description='+encodeURIComponent(document.getSelection())+'&source=bookmarklet','_blank','menubar=no,height=800,width=600,toolbar=no,scrollbars=yes,status=no,dialog=1')}();";
-    executeScript(shaarliInstance, myCode);
-  });
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === "install") {
+    chrome.runtime.openOptionsPage();
+  }
+});
+
+function addUrl(tab) {
+  chrome.storage.sync.get(
+    {
+      savedShaarliInstance: defaultShaarliInstance,
+    },
+    function (items) {
+      const shaarliInstance = items.savedShaarliInstance;
+      if (
+        shaarliInstance === defaultShaarliInstance ||
+        shaarliInstance === ""
+      ) {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: () => {
+            alert(
+              "Please setup your Shaarli instance in the options of the extension."
+            );
+          },
+        });
+      } else {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ["addUrl.js"],
+        });
+      }
+    }
+  );
 }
 
-function addNote() {
-  chrome.storage.sync.get({
-    savedShaarliInstance: defaultShaarliInstance
-  }, function (items) {
-    let shaarliInstance = items.savedShaarliInstance;
-    let myCode = "!function(){var e=document.title;const popup=window.open('" +
-      shaarliInstance +
-      "?post='+'&description='+encodeURIComponent(document.getSelection()),'_blank','menubar=no,height=800,width=600,toolbar=no,scrollbars=yes,status=no,dialog=1')}();";
-    executeScript(shaarliInstance, myCode);
-  });
+function addNote(tab) {
+  chrome.storage.sync.get(
+    {
+      savedShaarliInstance: defaultShaarliInstance,
+    },
+    function (items) {
+      const shaarliInstance = items.savedShaarliInstance;
+      if (
+        shaarliInstance === defaultShaarliInstance ||
+        shaarliInstance === ""
+      ) {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: () => {
+            alert(
+              "Please setup your Shaarli instance in the options of the extension."
+            );
+          },
+        });
+      } else {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ["addNote.js"],
+        });
+      }
+    }
+  );
 }
 
-function executeScript(shaarliInstance, code) {
-  if (shaarliInstance === defaultShaarliInstance || shaarliInstance === "")
-    code = "alert('Please setup your Shaarli instance in the options of the extension.')";
-  chrome.tabs.query({
-    active: true
-  }, function () {
-    chrome.tabs.executeScript({
-      code: code
-    });
-  });
-}
-
-chrome.commands.onCommand.addListener(function (command) {
+chrome.commands.onCommand.addListener(function (command, tab) {
   switch (command) {
     case "add-url":
-      addUrl();
+      addUrl(tab);
       break;
     case "add-note":
-      addNote();
+      addNote(tab);
       break;
   }
 });
 
-chrome.browserAction.onClicked.addListener(function () {
-  addUrl();
+chrome.action.onClicked.addListener(function (tab) {
+  addUrl(tab);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,31 +1,27 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Add to Shaarli",
   "description": "This extension lets you add the current tab or a note to your Shaarli instance.",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "icon.png"
   },
-
   "options_page": "options.html",
-  "options_ui": {
-    "page": "options.html",
-    "open_in_tab": false
-  },
   "background": {
-    "scripts": [
-      "background.js"
-    ],
-    "persistent": false
+    "service_worker": "background.js"
   },
   "permissions": [
+    "storage",
     "activeTab",
-    "storage"
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "commands": {
     "add-url": {
@@ -40,5 +36,8 @@
       },
       "description": "Add a note"
     }
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Add to Shaarli",
   "description": "This extension lets you add the current tab or a note to your Shaarli instance.",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
Hello burgyl,

Thank you for a great extension which I love using with Shaarli. Unfortunately it has fallen short of the recent updates and requirements to chrome extensions. I hope to fix that with this pull request. It migrates the extension from the deprecated Manifest V2 to Manifest V3 to comply with the latest Chrome Web Store policies.

Key changes include:
- Updated `manifest.json` to version 3.
- Replaced `chrome.tabs.executeScript` with the more secure `chrome.scripting.executeScript`.
- Converted the background script to a service worker.
- Moved injected code from inline strings to separate files (`addUrl.js`, `addNote.js`).

I've used this version as a local install for the last week, which works, but I don't have a chrome web store developer account, so I can't actually check if the extension meets the requirements.

Best,

voss